### PR TITLE
Update HikariCP maxlifetime configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 
 ### VS Code ###
 .vscode/
+api.http

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -12,6 +12,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${SPRING_DATASOURCE_ENDPOINT}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${SPRING_DATASOURCE_USERNAME}
+    hikari:
+      max-lifetime: 1190000
 
 # Redis
   data:


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] feat: 새로운 기능 추가

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
featl/login -> main

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
HikariCP의 maxlifetime을 MySQL의 wait_timeout보다 10초 짧게 설정(1190초)

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
server [feat/login] ./gradlew clean check test
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2025-06-18T09:05:42.492+09:00  INFO 15875 --- [server] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
Hibernate: drop table if exists member cascade 

[Incubating] Problems report is available at: file:///workspace/server/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 19s
10 actionable tasks: 10 executed

### 📂 관련 이슈
<!-- 예) #5 -->
#11 

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
