### PR TITLE
Enhance JWT error handling with logging

### DIFF
--- a/src/main/java/com/und/server/exception/ServerErrorResult.java
+++ b/src/main/java/com/und/server/exception/ServerErrorResult.java
@@ -16,6 +16,7 @@ public enum ServerErrorResult {
 	INVALID_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "Invalid Public Key"),
 	PUBLIC_KEY_INVALID(HttpStatus.BAD_REQUEST, "Public Key Invalid"),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Expired Token"),
+	TOKEN_NOT_EXPIRED(HttpStatus.BAD_REQUEST, "Token Not Expired"),
 	MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "Malformed Token"),
 	INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "Invalid Signature"),
 	UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "Unsupported Token"),


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] refactor: 코드 리펙토링

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
feat/login -> main

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
`JwtProvider`에 로깅 추가
만료된 JWT에서 Member ID를 추출할 때 JWT가 만료되지 않았으면 `TOKEN_NOT_EXPIRED` 예외 처리

### 💯 테스트 결과
<img width="974" alt="Screenshot 2025-06-18 at 9 18 24 PM" src="https://github.com/user-attachments/assets/47646115-5ef0-4969-86b3-cfa3fa92ac61" />

<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

### 📂 관련 이슈
<!-- 예) #5 -->
#11 

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
